### PR TITLE
inject the newly created goosh.js.compr into the goosh.html file

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -13,7 +13,13 @@ echo "gzip"
 
 cat goosh.js.compr.tmp |sed s\#gshell.grothkopp.com\#goosh.org\#g |sed s\#ABQIAAAA0cXSEVCNSwf_x74KTtPJMRShYK5vgJfK0afUKMRqjECszDItkhTOIyZ74499O_ys5nJIQuP4sq4nZg\#ABQIAAAA0cXSEVCNSwf_x74KTtPJMRQP4Q7D8MPck7bhT7upyfJTzVDU2BRxkUdd2AvzlDDF7DNUJI_Y4eB6Ug\#g >goosh.js.compr
 
-wget 'http://n.goosh.org/?deploy=1' -O goosh.html -o /dev/null
+wget 'http://n.goosh.org/?deploy=1' -O goosh.html-dl -o /dev/null
+
+scriptLine=`grep -n "var goosh=new Object();" goosh.html-dl | cut -d : -f 1`
+
+cat goosh.html-dl | head -n $(($scriptLine-1)) > goosh.html
+cat goosh.js.compr >> goosh.html
+cat goosh.html-dl | tail -n +$(($scriptLine+1)) >> goosh.html
 
 #exit
 echo "copy files"

--- a/deploy.sh
+++ b/deploy.sh
@@ -24,7 +24,11 @@ cat goosh.html-dl | tail -n +$(($scriptLine+1)) >> goosh.html
 #exit
 echo "copy files"
 
-cp ../goosh.org/index.html ../goosh.org/index.html-autosave
+if [ ! -f ../goosh.org/index.html ]; then
+  mkdir ../goosh.org
+else
+  cp ../goosh.org/index.html ../goosh.org/index.html-autosave
+fi
 cp goosh.html ../goosh.org/index.html
 #echo "gzip"
 


### PR DESCRIPTION
I noticed while getting started with this that we wget what you have on the server to become our new index.html, but we never actually inject the new goosh.js.compr into it.
Every deploy it builds new js files, but then wgets the html that's hosted and never changes the script in the page.

This is getting the line number of where the script is in the page we download, write everything 'as is' up to the script, inject our newly generated script, continue writing the file 'as is'.
